### PR TITLE
Endret tekst i "Skriv til oss" i boksen "Får ikke reist til Norge"

### DIFF
--- a/src/language/en.ts
+++ b/src/language/en.ts
@@ -156,9 +156,9 @@ export default {
   "skrivtiloss.familieogbarn.lenke.tittel": "Parents, children and family",
   "skrivtiloss.pensjonist.lenke.tittel": "Pensioner",
   "skrivtiloss.ufor.lenke.tittel": "Disabled",
-  "skrivtiloss.reise.lenke.tittel": "Can't travel to Norway",
+  "skrivtiloss.reise.lenke.tittel": "CV on arbeidsplassen.no",
   "skrivtiloss.reise.lenke.description":
-    "Questions about how the travel restrictions affect your rights or benefits at NAV. The form is in Norwegian.",
+    "Questions about access for employers to the CV base on arbeidplassen.no. The form is in Norwegian.",
   "skrivtiloss.sosial.lenke.tittel":
     "Financial social assistance and other social assistance services",
   "skrivtiloss.hjelpemidler.lenke.tittel": "Assistive devices and technology",

--- a/src/language/nb.ts
+++ b/src/language/nb.ts
@@ -151,9 +151,9 @@ export default {
   "skrivtiloss.familieogbarn.lenke.tittel": "Foreldre, barn og familie",
   "skrivtiloss.pensjonist.lenke.tittel": "Pensjonist",
   "skrivtiloss.ufor.lenke.tittel": "Ufør",
-  "skrivtiloss.reise.lenke.tittel": "Får ikke reist til Norge",
+  "skrivtiloss.reise.lenke.tittel": "CV på arbeidsplassen.no",
   "skrivtiloss.reise.lenke.description":
-    "Spørsmål til hvordan innreisereglene påvirker dine rettigheter eller ytelser hos NAV.",
+    "Spørsmål om tilgang for arbeidsgivere til CV-er på arbeidsplassen.no",
   "skrivtiloss.sosial.lenke.tittel":
     "Økonomisk sosialhjelp og andre sosiale tjenester",
   "skrivtiloss.hjelpemidler.lenke.tittel": "Hjelpemidler",


### PR DESCRIPTION
Endret tekst i boksen "Får ikke reist til Norge"

Ny tittel: "CV på arbeidsplassen.no"
Tekst: "Spørsmål om tilgang for arbeidsgivere til CV-er på arbeidsplassen.no"
Engelsk: "CV on arbeidsplassen.no" og "Questions about access for employers to the CV base on arbeidplassen.no. The form is in Norwegian."

URL i boksen er fortsatt den samme.

Ref. issue https://github.com/navikt/pb-kontakt-oss/issues/265